### PR TITLE
optimismでNFTのmintをできるようにする

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ NEXT_PUBLIC_NODE_ENV="dev"
 NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID="1b5b1d5c351c838062b62002e37bee3c"
 NEXT_PUBLIC_WALLET_CONNECT_PROJECT_NAME="cit-web3-class"
 
-HENKAKU_API_BASE_URL=""
+HENKAKU_API_BASE_URL="https://api.staging.sakazuki.xyz/henkaku"
 
 # ====================================================[ CONTRACT ]====================================================
 NEXT_PUBLIC_CJPY_ADDRESS="0x0000000000000000000000000000000000000000"


### PR DESCRIPTION
# SUMMARY
optimismでNFTのmintをできるようにする
TICKET: https://www.notion.so/pitpa/Enable-NFT-Minting-on-Optimism-optimism-NFT-mint-1776aec30495806da52bc797768a1e28
## CHANGELOG

- [x] Update Henkaku API Base URL.